### PR TITLE
Build-time QML pre-compilation via asteroid_app_qml_module

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,10 @@
 add_library(asteroid-weather main.cpp resources.qrc)
 set_target_properties(asteroid-weather PROPERTIES PREFIX "")
 
+asteroid_app_qml_module(asteroid-weather
+	main.qml
+)
+
 target_link_libraries(
 	asteroid-weather
 	PUBLIC

--- a/src/resources.qrc
+++ b/src/resources.qrc
@@ -1,6 +1,5 @@
 <RCC>
     <qresource prefix="/">
-        <file>main.qml</file>
         <file>icons.js</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
The .so ships pre-compiled QML bytecode and the engine skips the parse/JIT pipeline on every launch.