### PR TITLE
Drop versioned imports

### DIFF
--- a/src/main.qml
+++ b/src/main.qml
@@ -16,9 +16,9 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.9
-import org.asteroid.controls 1.0
-import Nemo.Configuration 1.0
+import QtQuick
+import org.asteroid.controls
+import Nemo.Configuration
 import 'qrc:/icons.js' as IconTools
 
 Application {


### PR DESCRIPTION
Since the Qt6 migration, this is no longer useful